### PR TITLE
Randomly Spawn Codex Placeholders

### DIFF
--- a/Assets/Scripts/ProcGen/BoardCreator.cs
+++ b/Assets/Scripts/ProcGen/BoardCreator.cs
@@ -47,6 +47,9 @@ public class BoardCreator : MonoBehaviour
 	public int element = 0;
 	private int numAppend = 0;
 
+	public int CodexPercChance = 50;
+	public GameObject[] codexArray;							//The array that will hold the codexes to be spawned
+
     private void Start()
     {
 		//Set to false when starting the generation
@@ -504,7 +507,32 @@ public class BoardCreator : MonoBehaviour
 						tiles [xCoord] [yCoord] = TileType.Floor;
 					}
 				}
+				//Makes a roll
+				roll = Random.Range (0, 100);
+
+				//If the roll is a success
+				if (roll <= CodexPercChance) 
+				{
+					//Spawn the prefab in the correct position with respect to the direction of the corridor
+					element = Random.Range(0, codexArray.Length-1);
+					switch (currentCorridor.direction) 
+					{
+					case Direction.North:
+						Instantiate (codexArray[element], new Vector3 (currentCorridor.startXPos + currentCorridor.corridorWidth / 2.0f, currentCorridor.startYPos + currentCorridor.corridorLength-2, 0), Quaternion.identity);
+						break;
+					case Direction.East:
+						Instantiate (codexArray[element], new Vector3 (currentCorridor.startXPos + currentCorridor.corridorLength-2, currentCorridor.startYPos + currentCorridor.corridorWidth / 2.0f, 0), Quaternion.identity);
+						break;
+					case Direction.South:
+						Instantiate (codexArray[element], new Vector3 (currentCorridor.startXPos + currentCorridor.corridorWidth / 2.0f, currentCorridor.startYPos - currentCorridor.corridorLength+2, 0), Quaternion.identity);
+						break;
+					case Direction.West:
+						Instantiate (codexArray[element], new Vector3 (currentCorridor.startXPos - currentCorridor.corridorLength+2, currentCorridor.startYPos + currentCorridor.corridorWidth / 2.0f, 0), Quaternion.identity);
+						break;
+					}
+				}
 			}
+
 		}
 	}
     void InstantiateTiles()

--- a/Assets/Scripts/ProcGen/Corridor.cs
+++ b/Assets/Scripts/ProcGen/Corridor.cs
@@ -226,22 +226,22 @@ public class Corridor
 				//Then set the values
 				startXPos = Random.Range(corridor.startXPos-6, corridor.startXPos-corridor.corridorLength+6);
 				startYPos = corridor.startYPos + corridor.corridorWidth; 
-				maxLength = rows - startYPos - roomHeight.m_Min;
+				maxLength = rows - startYPos;
 				break;
 			case Direction.East:
 				startXPos = corridor.startXPos + corridor.corridorWidth;
 				startYPos = Random.Range(corridor.startYPos+8, corridor.startYPos+ corridor.corridorWidth-8);
-				maxLength = columns - startXPos - roomWidth.m_Min;
+				maxLength = columns - startXPos;
 				break;
 			case Direction.South:
 				startXPos = Random.Range (corridor.startXPos+8, corridor.startXPos + corridor.corridorLength-8);
 				startYPos = corridor.startYPos;
-				maxLength = startYPos - roomHeight.m_Min;
+				maxLength = startYPos;
 				break;
 			case Direction.West:
 				startXPos = corridor.startXPos;
 				startYPos = Random.Range (corridor.startYPos-corridor.corridorLength+8, corridor.startYPos-8);
-				maxLength = startXPos - roomWidth.m_Min;
+				maxLength = startXPos;
 				break;
 		}
 		// We clamp the length of the corridor to make sure it doesn't go off the board.


### PR DESCRIPTION
At the end of a dead end corridor there is a chance for a codex
placeholder, currently just memes, to spawn.

Also changed the maxLength of the dead end corridors so that dead end
corridors will properly be clamped to the board. Before if a dead end
corridor spawned within the length or width of a room from the edge (i.e
20 blocks in from any board edge) the dead end corridor will simply not
spawn. Changed it so that dead end corridors can now run to the board
edge.
